### PR TITLE
Added firewall rule to allow GKE control plane to reach Kubernetes Webhooks

### DIFF
--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -83,3 +83,17 @@ resource "google_compute_firewall" "ssh_to_nodes" {
 
   target_tags = ["sighup-io-gke-cluster-${var.cluster_name}"]
 }
+
+resource "google_compute_firewall" "gke_webhook" {
+  name          = "control-plane-access-to-${var.cluster_name}-worker-nodes"
+  description   = "Allow access from GKE masters to worker nodes to allow WebHook functionalities"
+  network       = var.network
+  source_ranges = [module.gke.master_ipv4_cidr_block]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
+
+  target_tags = ["sighup-io-gke-cluster-${var.cluster_name}"]
+}


### PR DESCRIPTION
While testing this installer we noticed that GKE control plane was not allowed to reach the worker nodes, this functionality is needed to allow the use of `ValidatingWebhookConfiguration` and `ValidatingWebhookConfiguration` Kubernetes resources.

The aim of this PR is to add a firewall rule to allow traffic from the GKE control plane CIDR to TCP/443 on worker nodes, here I am assuming that all webhooks will be exposed by Services on that port. If that's a too strong assumption, I can relax the rule.

Ref:
- https://cert-manager.io/docs/installation/compatibility/
- https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules