### PR TITLE
Add 'default_max_pods_per_node' variable

### DIFF
--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -51,6 +51,7 @@ module "gke" {
   disable_default_snat          = var.gke_disable_default_snat
   add_cluster_firewall_rules    = var.gke_add_cluster_firewall_rules
   master_ipv4_cidr_block        = var.gke_master_ipv4_cidr_block
+  default_max_pods_per_node     = var.gke_default_max_pods_per_node
   deploy_using_private_endpoint = true
   enable_private_endpoint       = true
   enable_private_nodes          = true

--- a/modules/gke/variables.tf
+++ b/modules/gke/variables.tf
@@ -87,3 +87,9 @@ variable "gke_disable_default_snat" {
   description = "[GKE] Whether to disable the default SNAT to support the private use of public IP addresses"
   default     = false
 }
+
+variable "gke_default_max_pods_per_node" {
+  type        = number
+  description = "[GKE] The maximum number of pods to schedule per node"
+  default     = 110
+}


### PR DESCRIPTION
Add the possibility to limit the maximum number of pods to be scheduled on a node.
This is necessary when we deal with small subnets.