### PR TITLE
pin kubernetes provider as it contains breaking changes on v2

### DIFF
--- a/modules/gke/README.md
+++ b/modules/gke/README.md
@@ -4,7 +4,7 @@
 | ----------- | --------- |
 | google      | >= 3.44.0 |
 | google-beta | >= 3.44.0 |
-| kubernetes  | >= 1.13.2 |
+| kubernetes  |  = 1.13.3 |
 | null        | >= 3.0.0  |
 | random      | >= 3.0.0  |
 | external    | >= 2.0.0  |

--- a/modules/gke/main.tf
+++ b/modules/gke/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google      = ">= 3.44.0"
     google-beta = ">= 3.44.0"
-    kubernetes  = ">= 1.13.2"
+    kubernetes  = "= 1.13.3"
     null        = ">= 3.0.0"
     random      = ">= 3.0.0"
     external    = ">= 2.0.0"


### PR DESCRIPTION
As said in the title, @nikever found an issue while using the eks installer related to the kubernetes provider.
Let's ping the version to a static one (latest v1 version)