### PR TITLE
Adding firewall rule for gatekeeper webhook

### DIFF
--- a/modules/gke/gke.tf
+++ b/modules/gke/gke.tf
@@ -197,3 +197,18 @@ resource "google_compute_firewall" "gke_webhook" {
 
   target_tags = ["sighup-io-gke-cluster-${var.cluster_name}"]
 }
+
+resource "google_compute_firewall" "gatekeeper_webhook" {
+  count         = var.gke_add_additional_firewall_rules ? 1 : 0
+  name          = "gatekeeper-webhook-access-to-${var.cluster_name}-worker-nodes"
+  description   = "Allow access from GKE masters to worker nodes to allow Gatekeeper WebHook"
+  network       = var.network
+  source_ranges = [module.gke.master_ipv4_cidr_block]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["8443"]
+  }
+
+  target_tags = ["sighup-io-gke-cluster-${var.cluster_name}"]
+}


### PR DESCRIPTION
This PR fixes [this issue on OPA module](https://github.com/sighupio/fury-kubernetes-opa/issues/28). Since in gke `enable-aggregator-routing` is true by default, an extra firewall rule is needed to allow gatekeeper communication. The rationale behind adding it in the installer is that OPA module is a mandatory module and to make it work in GKE this firewall rule needs to be added. 